### PR TITLE
for node >= v0.10.0 use global.setImmediate for nextTick

### DIFF
--- a/lib/vow.js
+++ b/lib/vow.js
@@ -402,7 +402,7 @@ var undef,
             if (ver[0] == 0 && ver[1] < 10)
                 return process.nextTick;
             else
-                return global.setImmediate; //v8 in at least node v0.10.0
+                return GLOBAL.setImmediate; //v8 in at least node v0.10.0
         }
 
         if(global.setImmediate) { // ie10


### PR DESCRIPTION
Tried to stick with your code style.

In node v0.10.0 you get warnings for very recursive calls to process.nextTick. They say to use globale.setImmediate.

This doesn't work but I can't retract a pull request. I thought it was so simple I didn't need to test it. Famous last words.
