### PR TITLE
In node v0.10.0 or greater I get the following error when executing deep...

### DIFF
--- a/lib/vow.js
+++ b/lib/vow.js
@@ -397,7 +397,12 @@ var Vow = {
 var undef,
     nextTick = (function() {
         if(typeof process === 'object') { // nodejs
-            return process.nextTick;
+            var ver = process.versions.node.split('.')
+                      .map(function(v){ return parseInt(v,10) })
+            if (ver[0] > 0 || ver[1] >= 10)
+                return GLOBAL.setImmediate
+            else
+                return process.nextTick;
         }
 
         if(global.setImmediate) { // ie10


### PR DESCRIPTION
...ly nested promises.

`(node) warning: Recursive process.nextTick detected. This will break in the next version of node. Please use setImmediate for recursive deferral.`

This seems to indicate that ANY recursive use of process.nextTick will be broken
in the next release of node.js .

Sorry about the late reply on the last attempt at a pull request. And the fact that it didn't work :) . I was fooled by the redefinition of `gobal`. This version is using `GLOBAL.setImmediate` (`root.setImmediate` would also work).
