### PR TITLE
Create .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+.*
+/benchmarks
+/test
+/Makefile


### PR DESCRIPTION
clean distribution
I see no sense having 1.7Mb of benchmarks just for 20k lib/vow.js file.
