### PR TITLE
valueOf > inpect

### DIFF
--- a/lib/vow.js
+++ b/lib/vow.js
@@ -275,7 +275,7 @@ var Vow = {
     },
 
     valueOf : function(obj) {
-        return Vow.isPromise(obj)? obj.valueOf() : obj;
+        return Vow.isPromise(obj)? obj.inspect() : obj;
     },
 
     isFulfilled : function(obj) {


### PR DESCRIPTION
Привет!

Уже давно проекты (которые используют borschik) падают с такой ошибкой:

```
valueOf is deprecated, use inspect instead. Error
    at Promise.valueOf (/Users/megatolya/workspace/bm-interface/node_modules/borschik/node_modules/coa/node_modules/q/q.js:452:39)
    at Object.Vow.valueOf (/Users/megatolya/workspace/bm-interface/node_modules/vow/lib/vow.js:278:40)
    at onFulfilled (/Users/megatolya/workspace/bm-interface/node_modules/vow/lib/vow.js:348:44)
    at _fulfilled (/Users/megatolya/workspace/bm-interface/node_modules/borschik/node_modules/coa/node_modules/q/q.js:798:54)
    at self.promiseDispatch.done (/Users/megatolya/workspace/bm-interface/node_modules/borschik/node_modules/coa/node_modules/q/q.js:827:30)
    at Promise.promise.promiseDispatch (/Users/megatolya/workspace/bm-interface/node_modules/borschik/node_modules/coa/node_modules/q/q.js:760:13)
    at /Users/megatolya/workspace/bm-interface/node_modules/borschik/node_modules/coa/node_modules/q/q.js:574:44
    at flush (/Users/megatolya/workspace/bm-interface/node_modules/borschik/node_modules/coa/node_modules/q/q.js:108:17)
    at process._tickCallback (node.js:415:13)
```

Возможно, я не правильно понял, какая библиотека все ломает, но я прошел по всему стеку, и кажется дело в `valueOf`. Еще подробности [тут](https://github.com/megatolya/grunt-borschik/issues/2)
