### PR TITLE
Fixed deoptimizations for V8, optimized the invoke method.

### DIFF
--- a/lib/vow.js
+++ b/lib/vow.js
@@ -869,7 +869,7 @@ var vow = /** @exports vow */ {
      */
     invoke : function(fn, args) {
         var
-            length = arguments.length - 1,
+            length = Math.max(arguments.length - 1, 0),
             index = 0,
             arg = new Array(length);
 


### PR DESCRIPTION
[deoptimizing: begin 0xebf2e219 isVowPromise @2]
  translating isVowPromise => node=3, height=0
    0x0027f588: [top + 40] <- 0xb78573a1 ; [sp + 40] 00000000B78573A1 <JS Global Object>
    0x0027f580: [top + 32] <- 0x300000000 ; rbx 3
    0x0027f578: [top + 24] <- 0xed295ee6 ; caller's pc
    0x0027f570: [top + 16] <- 0x0027f5b0 ; caller's fp
    0x0027f568: [top + 8] <- 0xebf2f689; context
    0x0027f560: [top + 0] <- 0xebf2e219; function
[deoptimizing: end 0xebf2e219 isVowPromise => node=3, pc=0xed2962c6, state=NO_REGISTERS, alignment=no padding, took 0.000 ms]
[removing optimized code for: isVowPromise]
