### PR TITLE
Pass `window` or `global` instead of `this`

### DIFF
--- a/lib/vow.js
+++ b/lib/vow.js
@@ -1325,4 +1325,4 @@ if(typeof define === 'function') {
 
 defineAsGlobal && (global.vow = vow);
 
-})(this);
+})(typeof window !== 'undefined' ? window : global);


### PR DESCRIPTION
A fix for correct work in closures, when `this` doesn't actually refer
to a global object (for example, in a browserify bundle)