### PR TITLE
Update benchmarks

### DIFF
--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -1,12 +1,13 @@
 {
-    "name" : "promises-library-speed-comparison",
-    "version" : "0.0.1",
-    "dependencies": {
-        "cliff" : "",
-        "benchmark" : "",
-        "q" : "1.0.1",
-        "when" : "3.5.0",
-        "bluebird" : "2.3.5"
-    },
-    "private" : true
+  "name": "promises-library-speed-comparison",
+  "version": "0.0.1",
+  "dependencies": {
+    "benchmark": "",
+    "bluebird": "3.0.2",
+    "cliff": "",
+    "pinkie-promise": "1.0.0",
+    "q": "1.0.1",
+    "when": "3.5.0"
+  },
+  "private": true
 }


### PR DESCRIPTION
- add ES2015 Promise
- add [pinkie-promise](https://github.com/floatdrop/pinkie-promise) (es6 promise polyfill)
- update bluebird to latest 3.x

Results on my laptop:

~~~
› node --version
v0.12.7

               mean time ops/sec
Q              4.809ms   208
When           1.641ms   609
Bluebird       2.131ms   469
Pinkie         4.308ms   232
ES2015 Promise 4.427ms   226
Vow            2.090ms   478
~~~

~~~
› node --version
v5.0.0

               mean time ops/sec
Q              4.694ms   213
When           1.972ms   507
Bluebird       1.993ms   502
Pinkie         2.597ms   385
ES2015 Promise 2.572ms   389
Vow            1.720ms   581
~~~