### PR TITLE
Fix bluebird require

### DIFF
--- a/benchmarks/comparison.js
+++ b/benchmarks/comparison.js
@@ -5,7 +5,7 @@ var cliff = require('cliff'),
     Vow = require('..'),
     Q = require('q'),
     When = require('when'),
-    Bluebird = require('Bluebird'),
+    Bluebird = require('bluebird'),
     Pinkie = require('pinkie-promise'),
     tests = {
         'Q' : function(deferred) {


### PR DESCRIPTION
Fix `bluebird` require for case sensitive file systems:

```
[kostya@arch vow]$ cd benchmarks && npm ls bluebird
promises-library-speed-comparison@0.0.1 /home/kostya/proj/vow/benchmarks
└── bluebird@3.0.2 

[kostya@arch vow]$ make benchmark 
node benchmarks/comparison.js
module.js:339
    throw err;
    ^

Error: Cannot find module 'Bluebird'
    at Function.Module._resolveFilename (module.js:337:15)
    at Function.Module._load (module.js:287:25)
    at Module.require (module.js:366:17)
    at require (module.js:385:17)
    at Object.<anonymous> (/home/kostya/proj/vow/benchmarks/comparison.js:8:16)
    at Module._compile (module.js:435:26)
    at Object.Module._extensions..js (module.js:442:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:311:12)
    at Function.Module.runMain (module.js:467:10)
Makefile:5: recipe for target 'benchmark' failed
make: *** [benchmark] Error 1

```