### PR TITLE
Fix comparison

### DIFF
--- a/benchmarks/comparison.js
+++ b/benchmarks/comparison.js
@@ -152,9 +152,9 @@ var cliff = require('cliff'),
                 topPromises = Object.keys(data).map(function(key) {
                     var defer = Vow.defer();
                     Vow.all(data[key].map(function(val) {
-                            var resolver = Vow.defer();
+                            var defer = Vow.defer();
                             toResolve.push({ defer : defer, val : val });
-                            return resolver.promise();
+                            return defer.promise();
                         }))
                         .then(function(val) {
                             defer.resolve(val);


### PR DESCRIPTION
before:
```
               mean time ops/sec
Q              6.104ms   164
When           2.110ms   474
Bluebird       2.405ms   416
Pinkie         5.646ms   177
ES2015 Promise 5.667ms   176
Vow            2.090ms   478
```

after:
```
               mean time ops/sec
Q              6.194ms   161
When           2.092ms   478
Bluebird       2.491ms   401
Pinkie         5.606ms   178
ES2015 Promise 5.830ms   172
Vow            2.504ms   399
```

`"Fix" benchmark` commit(https://github.com/dfilatov/vow/commit/013ab8b1e37c24a77aa59ff2dabcd425cae53efe) looks suspicious... ;)
![suspicious](https://cloud.githubusercontent.com/assets/2646150/11104330/195e7c68-88d9-11e5-996a-fc42049bf4b4.jpg)
