### PR TITLE
Update benchmark dependencies

### DIFF
--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -3,11 +3,11 @@
   "version": "0.0.1",
   "dependencies": {
     "benchmark": "",
-    "bluebird": "3.0.2",
+    "bluebird": "3.4.0",
     "cliff": "",
-    "pinkie-promise": "1.0.0",
-    "q": "1.0.1",
-    "when": "3.5.0"
+    "pinkie-promise": "2.0.1",
+    "q": "1.4.1",
+    "when": "3.7.7"
   },
   "private": true
 }


### PR DESCRIPTION
```
node 7.0.0-nightly20160604de0aa23ad7
               mean time ops/sec
Q              3.414ms   293
When           0.584ms   1713
Bluebird       0.234ms   4274
Pinkie         0.987ms   1014
ES2015 Promise 0.987ms   1013
Vow            0.465ms   2150

node 7.0.0-nightly20160604de0aa23ad7 + new deps
               mean time ops/sec
Q              2.991ms   334
When           0.239ms   4189
Bluebird       0.237ms   4217
Pinkie         1.033ms   968
ES2015 Promise 1.005ms   995
Vow            0.457ms   2189

node 6.0.0
               mean time ops/sec
Q              3.538ms   283
When           0.531ms   1883
Bluebird       0.260ms   3842
Pinkie         1.148ms   871
ES2015 Promise 1.412ms   708
Vow            0.494ms   2026

node 6.0.0 + new deps
               mean time ops/sec
Q              3.255ms   307
When           1.052ms   951
Bluebird       0.256ms   3904
Pinkie         1.059ms   945
ES2015 Promise 0.990ms   1010
Vow            0.470ms   2127

node 4.4.2
               mean time ops/sec
Q              2.887ms   346
When           0.466ms   2144
Bluebird       0.500ms   1999
Pinkie         1.080ms   926
ES2015 Promise 1.063ms   941
Vow            0.437ms   2291

node 4.4.2 + new deps
               mean time ops/sec
Q              2.884ms   347
When           0.465ms   2153
Bluebird       0.468ms   2137
Pinkie         0.995ms   1005
ES2015 Promise 1.004ms   996
Vow            0.406ms   2463
```