### PR TITLE
Add core-js to benchmarks

### DIFF
--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -5,6 +5,7 @@
     "benchmark": "",
     "bluebird": "3.4.0",
     "cliff": "",
+    "core-js": "2.4.0",
     "pinkie-promise": "2.0.1",
     "q": "1.4.1",
     "when": "3.7.7"


### PR DESCRIPTION
[core-js](https://github.com/zloirock/core-js) provides ES6 polyfills used by babel-polyfill / babel-runtime

Results from my machine:

~~~
  › node --version
v4.4.7

                mean time ops/sec
Q               4.321ms   231
When            1.934ms   517
Bluebird        2.039ms   490
Pinkie          2.635ms   379
ES2015 Promise  2.628ms   381
core-js Promise 4.562ms   219
Vow             1.888ms   530
~~~

~~~
  › node-6 --version
v6.2.1

                mean time ops/sec
Q               4.177ms   239
When            1.975ms   506
Bluebird        1.714ms   583
Pinkie          2.610ms   383
ES2015 Promise  2.605ms   384
core-js Promise 2.058ms   486
Vow             2.300ms   435
~~~